### PR TITLE
DROID-2-Prepare Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,9 @@ Currently, the Repository only fetches the data form the server to provide it to
 The Repository will be updated to support data persistence using Room.
 After updating this, the ViewModel would not need any changes regarding this.
 
+#### Current Situation
+Right now, we finished a basic API connection to the backend.
+The main fragment uses its ViewModel to get the data and prints a debug log with the name of the station in LogCat.
+Currently the Lat and Lang of the German city of Cologne are hardcoded for testing and will be updated after UI preparation is done.     
+
 ### More comes as the project evolves.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,11 @@
 We will use Android Architecture components during the process. 
 More information about app architecture: [Guide to app architecture](https://developer.android.com/jetpack/docs/guide)
 
+We will also be using toolset provided by the Android KTX which is included in the Jetpack
+
+#### Repository
+Currently, the Repository only fetches the data form the server to provide it to the ViewModel.
+The Repository will be updated to support data persistence using Room.
+After updating this, the ViewModel would not need any changes regarding this.
+
 ### More comes as the project evolves.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # breathe-air-android
+
+⚠️This project is currently under construction and has no working functionalities.
+
+### More comes as the project evolves.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # breathe-air-android
 
-⚠️This project is currently under construction and has no working functionalities.
+⚠️This project is "under construction" and has no working functionalities.
+
+We will use Android Architecture components during the process. 
+More information about app architecture: [Guide to app architecture](https://developer.android.com/jetpack/docs/guide)
 
 ### More comes as the project evolves.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,10 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     buildTypes {
         release {
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,12 +26,17 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.core:core-ktx:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+
+    // network
+    implementation 'com.squareup.retrofit2:retrofit:2.7.1'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.squareup.retrofit2:converter-gson:2.6.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,10 +27,10 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,4 +18,6 @@
         </activity>
     </application>
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
 </manifest>

--- a/app/src/main/java/com/yellowdev/breatheair/StationDataRepository.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/StationDataRepository.kt
@@ -1,0 +1,45 @@
+package com.yellowdev.breatheair
+
+import com.yellowdev.breatheair.model.jsonmodels.GetWeatherDataPostRequestBody
+import com.yellowdev.breatheair.model.jsonmodels.StationData
+import com.yellowdev.breatheair.network.BreatheAirService
+import com.yellowdev.breatheair.network.ServiceGenerator
+
+/**
+ * Created by Ali Kabiri on 2020-01-18.
+ */
+open class StationDataRepository {
+
+    enum class RepositoryResponse {
+        BAD_BODY_DATA,
+        AUTH_INVALID,
+        NO_INTERNET_CONNECTION,
+        ENDPOINT_NOT_REACHABLE,
+        ENDPOINT_RESPONDED_WITH_UNKNOWN_ERROR,
+        UNDERLYING_AUTH_ERROR,
+    }
+
+    interface RepositoryCallBack {
+
+        fun done(info: RepositoryResponse)
+    }
+
+    lateinit var callBack: RepositoryCallBack
+
+    private var pBreatheAirService: BreatheAirService? = null
+    var breatheAirService: BreatheAirService
+        get() {
+            if (pBreatheAirService == null)
+                pBreatheAirService = ServiceGenerator.getBreatheAirService()
+            return pBreatheAirService as BreatheAirService
+        }
+        set(value) {
+            pBreatheAirService = value // will be used for testing.
+        }
+
+    open suspend fun getStationData(lat: String, long: String): StationData? {
+
+        return breatheAirService.getData(GetWeatherDataPostRequestBody(lat, long)).body()
+    }
+
+}

--- a/app/src/main/java/com/yellowdev/breatheair/model/jsonmodels/GetWeatherDataPostRequestBody.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/model/jsonmodels/GetWeatherDataPostRequestBody.kt
@@ -1,0 +1,10 @@
+package com.yellowdev.breatheair.model.jsonmodels
+
+/**
+ * Created by Ali Kabiri on 2020-01-17.
+ */
+
+data class GetWeatherDataPostRequestBody (
+    var lat: String,
+    var long: String
+)

--- a/app/src/main/java/com/yellowdev/breatheair/model/jsonmodels/StationData.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/model/jsonmodels/StationData.kt
@@ -1,0 +1,38 @@
+package com.yellowdev.breatheair.model.jsonmodels
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Created by Ali Kabiri on 2020-01-17.
+ */
+
+data class StationData (
+
+    var uuid: String,
+    var date: String,
+    var error: String,
+    var location: Location,
+    var offerToDo: ArrayList<Offer>,
+    var data: WeatherData
+
+) {
+    data class Location(
+        var lat: String,
+        var lon: String,
+        var name: String
+    )
+
+    data class Offer(
+        var text: String,
+        var imageUrl: String
+    )
+
+    data class WeatherData(
+        @SerializedName("AQIIndex")
+        var aqiIndex: Int,
+        var pm2: Int,
+        var pm10: Int,
+        var co2: Int,
+        var others: ArrayList<Any> // any for now.
+    )
+}

--- a/app/src/main/java/com/yellowdev/breatheair/network/BreatheAirService.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/network/BreatheAirService.kt
@@ -1,0 +1,13 @@
+package com.yellowdev.breatheair.network
+
+/**
+ * Created by Ali Kabiri on 2020-01-05.
+ */
+
+interface BreatheAirService {
+
+    companion object {
+        const val BASE_URL = "https://breatherair.herokuapp.com"
+        const val API_ROOT = "$BASE_URL/api"
+    }
+}

--- a/app/src/main/java/com/yellowdev/breatheair/network/BreatheAirService.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/network/BreatheAirService.kt
@@ -12,11 +12,11 @@ import retrofit2.http.POST
 
 interface BreatheAirService {
 
-    @POST("/location")
+    @POST("location")
     suspend fun getData(@Body requestBody: GetWeatherDataPostRequestBody): Response<StationData>
 
     companion object {
         const val BASE_URL = "https://breatherair.herokuapp.com"
-        const val API_ROOT = "$BASE_URL/api"
+        const val API_ROOT = "$BASE_URL/api/"
     }
 }

--- a/app/src/main/java/com/yellowdev/breatheair/network/BreatheAirService.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/network/BreatheAirService.kt
@@ -1,10 +1,19 @@
 package com.yellowdev.breatheair.network
 
+import com.yellowdev.breatheair.model.jsonmodels.StationData
+import com.yellowdev.breatheair.model.jsonmodels.GetWeatherDataPostRequestBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
 /**
  * Created by Ali Kabiri on 2020-01-05.
  */
 
 interface BreatheAirService {
+
+    @POST("/location")
+    suspend fun getData(@Body requestBody: GetWeatherDataPostRequestBody): Response<StationData>
 
     companion object {
         const val BASE_URL = "https://breatherair.herokuapp.com"

--- a/app/src/main/java/com/yellowdev/breatheair/network/ServiceGenerator.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/network/ServiceGenerator.kt
@@ -14,13 +14,13 @@ class ServiceGenerator {
         fun getBreatheAirService(): BreatheAirService {
 
             val builder = Retrofit.Builder()
-                .baseUrl(BreatheAirService.BASE_URL)
+                .baseUrl(BreatheAirService.API_ROOT)
                 .addConverterFactory(GsonConverterFactory.create())
 
             val retrofit = builder.build()
 
             // define interceptors.
-            // define custom okhttp client.
+            // define custom okHttp client.
 
             // add the interceptor and custom okhttp client.
             return retrofit.create(BreatheAirService::class.java)

--- a/app/src/main/java/com/yellowdev/breatheair/network/ServiceGenerator.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/network/ServiceGenerator.kt
@@ -1,0 +1,8 @@
+package com.yellowdev.breatheair.network
+
+/**
+ * Created by Ali Kabiri on 2020-01-05.
+ */
+
+class ServiceGenerator {
+}

--- a/app/src/main/java/com/yellowdev/breatheair/network/ServiceGenerator.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/network/ServiceGenerator.kt
@@ -1,8 +1,29 @@
 package com.yellowdev.breatheair.network
 
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
 /**
  * Created by Ali Kabiri on 2020-01-05.
  */
 
 class ServiceGenerator {
+
+    companion object {
+
+        fun getBreatheAirService(): BreatheAirService {
+
+            val builder = Retrofit.Builder()
+                .baseUrl(BreatheAirService.BASE_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+
+            val retrofit = builder.build()
+
+            // define interceptors.
+            // define custom okhttp client.
+
+            // add the interceptor and custom okhttp client.
+            return retrofit.create(BreatheAirService::class.java)
+        }
+    }
 }

--- a/app/src/main/java/com/yellowdev/breatheair/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/ui/main/MainFragment.kt
@@ -1,16 +1,19 @@
 package com.yellowdev.breatheair.ui.main
 
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import androidx.fragment.app.Fragment
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.yellowdev.breatheair.R
 
 class MainFragment : Fragment() {
 
     companion object {
+        private const val TAG = "MainActivity"
         fun newInstance() = MainFragment()
     }
 
@@ -23,8 +26,15 @@ class MainFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
-        // TODO: Use the ViewModel
-    }
+        viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
 
+        // lat, lang of the Kölle!
+        val lat = 50.935173
+        val lang = 6.953101
+        // TODO - replace this after the UI is ready.
+        val stationData = viewModel.getStationData(lat.toString(), lang.toString())
+        stationData.observe(viewLifecycleOwner, Observer {
+            Log.d(TAG, it.location.name)
+        })
+    }
 }

--- a/app/src/main/java/com/yellowdev/breatheair/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/ui/main/MainViewModel.kt
@@ -1,7 +1,26 @@
 package com.yellowdev.breatheair.ui.main
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yellowdev.breatheair.StationDataRepository
+import com.yellowdev.breatheair.model.jsonmodels.StationData
+import kotlinx.coroutines.launch
 
 class MainViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
+
+    private val stationDataRepository = StationDataRepository()
+
+    private lateinit var stationData: LiveData<StationData>
+
+    fun getStationData(lat: String, lang: String): LiveData<StationData> {
+
+        val liveStationData = MutableLiveData<StationData>()
+        viewModelScope.launch {
+            val stationData = stationDataRepository.getStationData(lat, lang)
+            liveStationData.postValue(stationData)
+        }
+        return liveStationData
+    }
 }

--- a/app/src/main/java/com/yellowdev/breatheair/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/yellowdev/breatheair/ui/main/MainViewModel.kt
@@ -12,8 +12,6 @@ class MainViewModel : ViewModel() {
 
     private val stationDataRepository = StationDataRepository()
 
-    private lateinit var stationData: LiveData<StationData>
-
     fun getStationData(lat: String, lang: String): LiveData<StationData> {
 
         val liveStationData = MutableLiveData<StationData>()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Added a basic retrofit generator class `ServiceGenerator` along with the necessary Service interface `BreatheAirService`, and the necessary JSON models. Specific network classes can be found under the network package.

Since this was the beginning of the project, it also involved creating the repository class `StationDataRepository` to access the data using the web service. This class will also contain the data persistence logic using Room in the near future.

I also had to update the `MainViewModel` to use the repository method and prepare the live data for the UI. It uses `viewModelScope.launch{}` to launch the suspended methods in the repository (coroutine scope).